### PR TITLE
feat(github): add flipt tag driven protobuf generate action

### DIFF
--- a/.github/workflows/proto-upgrade.yml
+++ b/.github/workflows/proto-upgrade.yml
@@ -1,0 +1,57 @@
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Flipt release version tag to generate
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: proto-upgrade
+jobs:
+  proto-upgrade:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
+      - name: Clone Flipt into sub-directory
+        run: gh repo clone flipt-io/flipt
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Bootstrap Tools
+        run: |
+          pushd ./flipt
+          git checkout ${{ inputs.tag }}
+          ./script/bootstrap
+          popd
+
+      - name: Buf Generate
+        run: buf generate
+
+      - name: Remove Flipt
+        run: rm -rf ./flipt/
+
+      - name: Prepare Branch
+        env:
+          GIT_AUTHOR_NAME: flipt-bot
+          GIT_AUTHOR_EMAIL: dev@flipt.io
+          GIT_COMMITTER_NAME: flipt-bot
+          GIT_COMMITTER_EMAIL: dev@flipt.io
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git checkout -b "generate/${{ inputs.tag }}"
+          git add --all .
+          git commit -m "feat: updates to protobuf definitions for flipt ${{ inputs.tag }}"
+          git push origin "generate/${{ inputs.tag }}"
+          gh pr create --title "feat: updates to protobuf definitions for flipt ${{ inputs.tag }}" \
+            --body "Upgrading generated client to the protobuf definitions found in Flipt ${{ inputs.tag }}."
+

--- a/.github/workflows/proto-upgrade.yml
+++ b/.github/workflows/proto-upgrade.yml
@@ -1,4 +1,5 @@
 on:
+  push:
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/proto-upgrade.yml
+++ b/.github/workflows/proto-upgrade.yml
@@ -1,5 +1,4 @@
 on:
-  push:
   workflow_dispatch:
     inputs:
       tag:

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,0 +1,10 @@
+version: v1
+plugins:
+  - name: go
+    out: .
+    opt:
+      - paths=source_relative
+  - name: go-grpc
+    out: .
+    opt:
+      - paths=source_relative

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,10 +1,6 @@
 version: v1
 plugins:
-  - name: go
-    out: .
-    opt:
-      - paths=source_relative
-  - name: go-grpc
-    out: .
-    opt:
-      - paths=source_relative
+  - remote: buf.build/protocolbuffers/plugins/ruby:v3.19.1-1
+    out: ./lib
+  - remote: buf.build/grpc/plugins/ruby:v1.41.1-1
+    out: ./lib

--- a/buf.work.yaml
+++ b/buf.work.yaml
@@ -1,0 +1,3 @@
+version: v1
+directories:
+  - flipt/rpc/flipt


### PR DESCRIPTION
This is a port of the change introduce into `flipt-io/flipt-grpc-go`.
The action here is triggered by workflow dispatch with a single input `tag`.
It is used to create a PR with the generated updates to the gRPC clients.